### PR TITLE
fix: eliminate race condition and credential exposure in custom passw…

### DIFF
--- a/password-grant/spring-boot-3-4-3/pom.xml
+++ b/password-grant/spring-boot-3-4-3/pom.xml
@@ -66,6 +66,18 @@
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<includes>
+						<include>**/*Test.java</include>
+						<include>**/*Tests.java</include>
+						<include>**/*IT.java</include>
+					</includes>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-resources-plugin</artifactId>
 				<version>3.1.0</version> <!--$NO-MVN-MAN-VER$ -->
 			</plugin>

--- a/password-grant/spring-boot-3-4-3/src/main/java/com/devsuperior/demo/config/customgrant/CustomPasswordAuthenticationConverter.java
+++ b/password-grant/spring-boot-3-4-3/src/main/java/com/devsuperior/demo/config/customgrant/CustomPasswordAuthenticationConverter.java
@@ -63,13 +63,15 @@ public class CustomPasswordAuthenticationConverter implements AuthenticationConv
 		Map<String, Object> additionalParameters = new HashMap<>();
 		parameters.forEach((key, value) -> {
 			if (!key.equals(OAuth2ParameterNames.GRANT_TYPE) &&
-					!key.equals(OAuth2ParameterNames.SCOPE)) {
+					!key.equals(OAuth2ParameterNames.SCOPE) &&
+					!key.equals(OAuth2ParameterNames.USERNAME) &&
+					!key.equals(OAuth2ParameterNames.PASSWORD)) {
 				additionalParameters.put(key, value.get(0));
 			}
 		});
 		
 		Authentication clientPrincipal = SecurityContextHolder.getContext().getAuthentication();	
-		return new CustomPasswordAuthenticationToken(clientPrincipal, requestedScopes, additionalParameters);
+		return new CustomPasswordAuthenticationToken(clientPrincipal, requestedScopes, additionalParameters, username, password);
 	}
 
 	private static MultiValueMap<String, String> getParameters(HttpServletRequest request) {

--- a/password-grant/spring-boot-3-4-3/src/main/java/com/devsuperior/demo/config/customgrant/CustomPasswordAuthenticationProvider.java
+++ b/password-grant/spring-boot-3-4-3/src/main/java/com/devsuperior/demo/config/customgrant/CustomPasswordAuthenticationProvider.java
@@ -1,7 +1,6 @@
 package com.devsuperior.demo.config.customgrant;
 
 import java.security.Principal;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -39,9 +38,6 @@ public class CustomPasswordAuthenticationProvider implements AuthenticationProvi
 	private final UserDetailsService userDetailsService;
 	private final OAuth2TokenGenerator<? extends OAuth2Token> tokenGenerator;
 	private final PasswordEncoder passwordEncoder;
-	private String username = "";
-	private String password = "";
-	private Set<String> authorizedScopes = new HashSet<>();
 
 	public CustomPasswordAuthenticationProvider(OAuth2AuthorizationService authorizationService,
 			OAuth2TokenGenerator<? extends OAuth2Token> tokenGenerator, 
@@ -63,25 +59,25 @@ public class CustomPasswordAuthenticationProvider implements AuthenticationProvi
 		CustomPasswordAuthenticationToken customPasswordAuthenticationToken = (CustomPasswordAuthenticationToken) authentication;
 		OAuth2ClientAuthenticationToken clientPrincipal = getAuthenticatedClientElseThrowInvalidClient(customPasswordAuthenticationToken);
 		RegisteredClient registeredClient = clientPrincipal.getRegisteredClient();
-		username = customPasswordAuthenticationToken.getUsername();
-		password = customPasswordAuthenticationToken.getPassword();	
-		
-		UserDetails user = null;
+		String username = customPasswordAuthenticationToken.getUsername();
+		String password = customPasswordAuthenticationToken.getPassword();
+
+		UserDetails user;
 		try {
 			user = userDetailsService.loadUserByUsername(username);
 		} catch (UsernameNotFoundException e) {
 			throw new OAuth2AuthenticationException("Invalid credentials");
 		}
-				
+
 		if (!passwordEncoder.matches(password, user.getPassword()) || !user.getUsername().equals(username)) {
 			throw new OAuth2AuthenticationException("Invalid credentials");
 		}
-		
-		authorizedScopes = user.getAuthorities().stream()
+
+		Set<String> authorizedScopes = user.getAuthorities().stream()
 				.map(scope -> scope.getAuthority())
 				.filter(scope -> registeredClient.getScopes().contains(scope))
 				.collect(Collectors.toSet());
-		
+
 		//-----------Create a new Security Context Holder Context----------
 		OAuth2ClientAuthenticationToken oAuth2ClientAuthenticationToken = (OAuth2ClientAuthenticationToken) SecurityContextHolder.getContext().getAuthentication();
 		CustomUserAuthorities customPasswordUser = new CustomUserAuthorities(username, user.getAuthorities());

--- a/password-grant/spring-boot-3-4-3/src/main/java/com/devsuperior/demo/config/customgrant/CustomPasswordAuthenticationToken.java
+++ b/password-grant/spring-boot-3-4-3/src/main/java/com/devsuperior/demo/config/customgrant/CustomPasswordAuthenticationToken.java
@@ -19,12 +19,13 @@ public class CustomPasswordAuthenticationToken extends OAuth2AuthorizationGrantA
 	private final Set<String> scopes;
 	
 	public CustomPasswordAuthenticationToken(Authentication clientPrincipal,
-			@Nullable Set<String> scopes, @Nullable Map<String, Object> additionalParameters) {
+			@Nullable Set<String> scopes, @Nullable Map<String, Object> additionalParameters,
+			String username, String password) {
 		
 		super(new AuthorizationGrantType("password"), clientPrincipal, additionalParameters);
 		
-		this.username = (String) additionalParameters.get("username");
-		this.password = (String) additionalParameters.get("password");
+		this.username = username;
+		this.password = password;
 		this.scopes = Collections.unmodifiableSet(
 				scopes != null ? new HashSet<>(scopes) : Collections.emptySet());
 	}


### PR DESCRIPTION
## Summary

Security hardening of the custom OAuth2 password grant implementation.
Fixes two critical issues identified during code review.

---

## Changes

### `CustomPasswordAuthenticationProvider.java` — Fix race condition (thread-safety)

`CustomPasswordAuthenticationProvider` is registered as a **singleton Spring bean**.
Three fields — `username`, `password`, and `authorizedScopes` — were declared as
mutable instance variables and written inside `authenticate()`.

Under concurrent load, Request A could overwrite these fields while Request B was
still reading them, causing **identity substitution** (user A receives a token
belonging to user B).

**Fix:** converted all three to local variables scoped inside `authenticate()`.
Removed the now-unused `import java.util.HashSet`.

### `CustomPasswordAuthenticationConverter.java` — Prevent plaintext credential persistence

The `additionalParameters` map passed to `CustomPasswordAuthenticationToken` previously
included the raw `username` and `password` values extracted from the HTTP request.
`OAuth2AuthorizationGrantAuthenticationToken` stores this map, and if the application
is ever switched to `JdbcOAuth2AuthorizationService` the **plaintext password would be
persisted to the database**.

**Fix:** added `OAuth2ParameterNames.USERNAME` and `OAuth2ParameterNames.PASSWORD` to
the exclusion filter so they are stripped from `additionalParameters` before the token
is constructed. Credentials are now passed as explicit constructor parameters instead.

### `CustomPasswordAuthenticationToken.java` — Cascading constructor fix

Because `username`/`password` were removed from `additionalParameters`, the constructor
that previously read them via `additionalParameters.get("username")` would have broken.

**Fix:** constructor signature updated to accept `username` and `password` as dedicated
`String` parameters; the converter is updated to supply them explicitly.

### `pom.xml` — Surefire includes for `*IT.java`

Maven Surefire's default pattern only discovers `*Test.java` / `*Tests.java`.
Integration test classes following the `*IT.java` convention were silently skipped
by `mvn test`.

**Fix:** added explicit `<includes>` configuration to `maven-surefire-plugin` so that
`*IT.java` classes are included in every test run.

---

## Testing

All 8 integration tests pass after these changes:
